### PR TITLE
:herb: Add GetById client methods

### DIFF
--- a/.fernignore
+++ b/.fernignore
@@ -1,1 +1,8 @@
 # Specify files that shouldn't be modified by Fern
+
+# Add GetById client methods.
+accesscodes/client/get_by_id.go
+actionattempts/get_by_id.go
+clientsessions/get_by_id.go
+connectwebviews/get_by_id.go
+webhooks/get_by_id.go

--- a/accesscodes/client/get_by_id.go
+++ b/accesscodes/client/get_by_id.go
@@ -1,0 +1,16 @@
+package client
+
+import (
+	context "context"
+
+	seamapigo "github.com/seamapi/go"
+)
+
+func (c *Client) GetById(ctx context.Context, accessCodeId string) (*seamapigo.AccessCode, error) {
+	return c.Get(
+		ctx,
+		&seamapigo.AccessCodesGetRequest{
+			AccessCodeId: seamapigo.String(accessCodeId),
+		},
+	)
+}

--- a/actionattempts/get_by_id.go
+++ b/actionattempts/get_by_id.go
@@ -1,0 +1,16 @@
+package actionattempts
+
+import (
+	context "context"
+
+	seamapigo "github.com/seamapi/go"
+)
+
+func (c *Client) GetById(ctx context.Context, actionAttemptId string) (*seamapigo.ActionAttempt, error) {
+	return c.Get(
+		ctx,
+		&seamapigo.ActionAttemptsGetRequest{
+			ActionAttemptId: actionAttemptId,
+		},
+	)
+}

--- a/clientsessions/get_by_id.go
+++ b/clientsessions/get_by_id.go
@@ -1,0 +1,16 @@
+package clientsessions
+
+import (
+	context "context"
+
+	seamapigo "github.com/seamapi/go"
+)
+
+func (c *Client) GetById(ctx context.Context, clientSessionId string) (*seamapigo.ClientSession, error) {
+	return c.Get(
+		ctx,
+		&seamapigo.ClientSessionsGetRequest{
+			ClientSessionId: seamapigo.String(clientSessionId),
+		},
+	)
+}

--- a/connectwebviews/get_by_id.go
+++ b/connectwebviews/get_by_id.go
@@ -1,0 +1,16 @@
+package connectwebviews
+
+import (
+	context "context"
+
+	seamapigo "github.com/seamapi/go"
+)
+
+func (c *Client) GetById(ctx context.Context, connectWebviewId string) (*seamapigo.ConnectWebview, error) {
+	return c.Get(
+		ctx,
+		&seamapigo.ConnectWebviewsGetRequest{
+			ConnectWebviewId: connectWebviewId,
+		},
+	)
+}

--- a/webhooks/get_by_id.go
+++ b/webhooks/get_by_id.go
@@ -1,0 +1,16 @@
+package webhooks
+
+import (
+	context "context"
+
+	seamapigo "github.com/seamapi/go"
+)
+
+func (c *Client) GetById(ctx context.Context, webhookId string) (*seamapigo.WebhooksGetResponse, error) {
+	return c.Get(
+		ctx,
+		&seamapigo.WebhooksGetRequest{
+			WebhookId: webhookId,
+		},
+	)
+}


### PR DESCRIPTION
This adds several `GetById` helper methods alongside the rest of the generated client methods for the following services:
* AccessCodes
* ActionAttempts
* ClientSessions
* ConnectWebviews
* Webhooks

Note that these custom methods are intentionally defined in a separate file so that can coexist alongside the generated files.