### PR TITLE
(fix): Temporarily change `startsAt` and `endsAt` types to `string*`

### DIFF
--- a/.fernignore
+++ b/.fernignore
@@ -5,6 +5,9 @@ README.md
 # Integration Tests
 test/
 
+# ISO Datetime Serialization
+acs/credentials.go
+
 # ci.yml installs Fake Seam
 .github/workflows/ci.yml
 

--- a/acs/credentials.go
+++ b/acs/credentials.go
@@ -6,7 +6,6 @@ import (
 	json "encoding/json"
 	fmt "fmt"
 	core "github.com/seamapi/go/core"
-	time "time"
 )
 
 type CredentialsAssignRequest struct {

--- a/acs/credentials.go
+++ b/acs/credentials.go
@@ -21,8 +21,8 @@ type CredentialsCreateRequest struct {
 	IsMultiPhoneSyncCredential *bool                                       `json:"is_multi_phone_sync_credential,omitempty"`
 	ExternalType               *CredentialsCreateRequestExternalType       `json:"external_type,omitempty"`
 	VisionlineMetadata         *CredentialsCreateRequestVisionlineMetadata `json:"visionline_metadata,omitempty"`
-	StartsAt                   *time.Time                                  `json:"starts_at,omitempty"`
-	EndsAt                     *time.Time                                  `json:"ends_at,omitempty"`
+	StartsAt                   *string                                     `json:"starts_at,omitempty"`
+	EndsAt                     *string                                     `json:"ends_at,omitempty"`
 }
 
 type CredentialsDeleteRequest struct {


### PR DESCRIPTION
The OpenAPI spec enforces RFC3339 for datetimes, the Seam backend expects a UTC time to be encoded with `Z`. In this PR, we temporarily update the `startsAt` and `endsAt` fields to be `string*` while the Fern team updates time serialization for the Go SDK generator. 